### PR TITLE
Works fine with ghc 7.8 (base 4.7)

### DIFF
--- a/gloss-banana.cabal
+++ b/gloss-banana.cabal
@@ -62,7 +62,7 @@ library
   default-extensions:    UnicodeSyntax, ScopedTypeVariables, RankNTypes
   
   -- Other library packages from which modules are imported.
-  build-depends:       base >=4.6 && <4.7,
+  build-depends:       base >=4.6 && <4.8,
                        gloss >=1.8 && <1.9,
                        reactive-banana >=0.7 && <0.8
   


### PR DESCRIPTION
I can confirm that your code works fine with ghc 7.8, and that the upper bound for base can thus be incremented.

There is also a new version of reactive-banana which came out, but your code isn't compatible with it (I have not looked into why).
