### PR TITLE
force event evaluation

### DIFF
--- a/Graphics/Gloss/Interface/FRP/ReactiveBanana.hs
+++ b/Graphics/Gloss/Interface/FRP/ReactiveBanana.hs
@@ -41,6 +41,13 @@ playBanana display colour frequency mPicture = do
     makeNetwork tickHandler eventHandler change = do
       eTick  ← fromAddHandler tickHandler
       eEvent ← fromAddHandler eventHandler
-      bPicture ← mPicture eTick eEvent
+      bRawPicture ← mPicture eTick eEvent
+      
+      -- make sure the Behavior doesn't leak memory if mPicture ignores
+      -- one or both kind of events
+      let bPicture = bRawPicture
+                  <* stepper undefined eTick
+                  <* stepper undefined eEvent
+      
       changes bPicture >>= reactimate . fmap change
       initial bPicture >>= liftIO . change


### PR DESCRIPTION
I [discovered](http://gelisam.blogspot.ca/2014/07/reactive-banana-mystery-leak.html) a pretty serious memory leak which occurs when one kind of events is _not_ used by the user's FRP expression. I am very new to reactive banana, so there might be easier ways to fix it, but this patch seems to work in all cases.
