### PR TITLE
bump version range to accept gloss-1.9

### DIFF
--- a/gloss-banana.cabal
+++ b/gloss-banana.cabal
@@ -63,7 +63,7 @@ library
   
   -- Other library packages from which modules are imported.
   build-depends:       base >=4.6 && <4.8,
-                       gloss >=1.8 && <1.9,
+                       gloss >=1.8 && <1.10,
                        reactive-banana >=0.8 && <0.9
   
   -- Directories containing source files.


### PR DESCRIPTION
Works just fine with the 1.9 series.